### PR TITLE
Upgrade to elrond-wasm 0.29.0, cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.27.0"
+version = "0.29.0"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.27.0"
+version = "0.29.0"

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.27.0"
+version = "0.29.0"
 
 [dependencies.elrond-wasm-debug]
-version = "0.27.0"
+version = "0.29.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub trait Attestation {
 		&self,
 		registration_cost: BigUint,
 		max_nonce_diff: u64,
-		#[var_args] attesters: ManagedVarArgs<ManagedAddress>,
+		#[var_args] attesters: MultiValueEncoded<ManagedAddress>,
 	) {
 		require!(!attesters.is_empty(), "Cannot have empty attester list");
 
@@ -193,11 +193,11 @@ pub trait Attestation {
 	fn get_user_state_endpoint(
 		&self,
 		obfuscated_data: ManagedByteArray<Self::Api, HASH_LEN>,
-	) -> OptionalResult<User<Self::Api>> {
+	) -> OptionalValue<User<Self::Api>> {
 		if !self.user_state(&obfuscated_data).is_empty() {
-			OptionalResult::Some(self.user_state(&obfuscated_data).get())
+			OptionalValue::Some(self.user_state(&obfuscated_data).get())
 		} else {
-			OptionalResult::None
+			OptionalValue::None
 		}
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub use value_state::ValueState;
 elrond_wasm::imports!();
 
 const HASH_LEN: usize = 32;
+const MAX_PRIVATE_INFO_LEN: usize = 1000;
 
 #[elrond_wasm::contract]
 pub trait Attestation {
@@ -141,7 +142,9 @@ pub trait Attestation {
 			"caller is not an attester"
 		);
 
-		let hashed = self.crypto().keccak256(&private_info);
+		let hashed = self
+			.crypto()
+			.keccak256_legacy_managed::<MAX_PRIVATE_INFO_LEN>(&private_info);
 		require!(
 			hashed == user_state.public_info,
 			"private/public info mismatch"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -20,8 +20,8 @@ path = ".."
 members = ["."]
 
 [dependencies.elrond-wasm-node]
-version = "0.27.0"
+version = "0.29.0"
 
 [dependencies.elrond-wasm-output]
-version = "0.27.0"
+version = "0.29.0"
 features = ["wasm-output-mode"]


### PR DESCRIPTION
Note: now using the legacy keccak hook, but with no allocator.